### PR TITLE
Feat/add chop end and start

### DIFF
--- a/support/str/str.go
+++ b/support/str/str.go
@@ -877,6 +877,30 @@ func (s *String) Words(limit int, end ...string) *String {
 	return s
 }
 
+// ChopEnd remove the given string(s) if it exists at the end of the haystack.
+func (s *String) ChopEnd(needle string, more ...string) *String {
+	more = append([]string{needle}, more...)
+
+	for _, v := range more {
+		if s.EndsWith(v) {
+			s.value = Substr(s.value, 0, -len(v))
+		}
+	}
+	return s
+}
+
+// ChopStart remove the given string(s) if it exists at the start of the haystack.
+func (s *String) ChopStart(needle string, more ...string) *String {
+	more = append([]string{needle}, more...)
+
+	for _, v := range more {
+		if s.StartsWith(v) {
+			s.value = Substr(s.value, len(v))
+		}
+	}
+	return s
+}
+
 // Substr returns a substring of a given string, starting at the specified index
 // and with a specified length.
 // It handles UTF-8 encoded strings.

--- a/support/str/str_test.go
+++ b/support/str/str_test.go
@@ -1030,6 +1030,20 @@ func (s *StringTestSuite) TestWords() {
 	s.Equal("Perfectly balanced, as all things should be.", Of("Perfectly balanced, as all things should be.").Words(100).String())
 }
 
+func (s *StringTestSuite) TestChopStart() {
+	s.Equal("Framework", Of("GoravelFramework").ChopStart("Goravel").String())
+	s.Equal("goravel.dev", Of("https://goravel.dev").ChopStart("https://").String())
+	s.Equal("goravel.dev", Of("https://goravel.dev").ChopStart("https", "://").String())
+	s.Equal("goravel", "go"+Of("laravel").ChopStart("la").String())
+}
+
+func (s *StringTestSuite) TestChopEnd() {
+	s.Equal("Goravel", Of("GoravelFramework").ChopEnd("Framework").String())
+	s.Equal("https://goravel", Of("https://goravel.dev").ChopEnd(".dev").String())
+	s.Equal("https://goravel", Of("https://goravel.dev").ChopEnd("dev", ".").String())
+	s.Equal("go", Of("golaravel").ChopEnd("laravel").String())
+}
+
 func TestFieldsFunc(t *testing.T) {
 	tests := []struct {
 		input          string


### PR DESCRIPTION
## 📑 Description
In this pull request, I have added two new string helper methods, chopStart and chopEnd, to Goravel. These methods are inspired by the corresponding Laravel string helpers.

Reference
For more details, refer to the official Laravel documentation: [String Helpers - chopStart and chopEnd](https://laravel.com/docs/11.x/strings#method-str-chop-start).

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
